### PR TITLE
Create secrets in AWS

### DIFF
--- a/.checkov-config.yml
+++ b/.checkov-config.yml
@@ -25,4 +25,6 @@ skip-check:
 - CKV_AWS_333
 # Disabled CKV2_GHA_1 as we want top level write permissions at the moment
 - CKV2_GHA_1
+# Disabled CKV2_AWS_57 as we don't want to require automatic rotation of secrets in this module
+- CKV2_AWS_57
 summary-position: top

--- a/.terraform-docs.yml
+++ b/.terraform-docs.yml
@@ -21,7 +21,7 @@ settings:
   escape: true
   hide-empty: false
   html: true
-  indent: 2
+  indent: 3
   lockfile: true
   read-comments: true
   required: true

--- a/.terraform-docs.yml
+++ b/.terraform-docs.yml
@@ -1,6 +1,6 @@
 formatter: markdown
 
-version: 0.17.0
+version: 0.19.0
 
 output:
   file: "README.md"

--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.88.0"
+  constraints = ">= 4.9.0"
+  hashes = [
+    "h1:8So0IR8jwKx8WhVuD1LDsbeMTe78/SF5g4d7z5C6+C4=",
+    "zh:24f852b1cca276d91f950cb7fb575cacc385f55edccf4beec1f611cdd7626cf5",
+    "zh:2a3b3f5ac513f8d6448a31d9619f8a96e0597dd354459de3a4698e684c909f96",
+    "zh:3700499885a8e0e532eccba3cb068340e411cf9e616bf8a59e815d3b62ca3e46",
+    "zh:4aab3605468244a74cbde66784ea1d30dc0fc6caf26d1b099427ecd5790f7c4d",
+    "zh:74eca9314d6dd80b215d7bc1c4be37d81e1045d625d5b512995f3a352d7a43bc",
+    "zh:77d9a06c63a4ad615bc97f67f948250397267f15698ebb2547fbdd20f734983c",
+    "zh:82d6aaef1eb0caf9ca451887fdbdcff10ab09318b1d60faa883a013283ab2b15",
+    "zh:8dbcfb121b887ce8572f5ab8174d592a729390ca32dc5fdacac4c7c1c508411a",
+    "zh:95d51e80b55ff9064f5c1bc61d78f992e2f89c986ba2b10546ea4461d35c24f9",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9ead5de0e123020926a0edaf88d9eed5cb86afe438a875528f6d11d0d27eed73",
+    "zh:ab7c940cbb2081314f4af3cdd61ed2c1d59fd7a60fa3db27770887d63072fbdd",
+    "zh:d52cd68006fd6fa8d028cdf569a6620fbc31726019beb7c75affa8764622d398",
+    "zh:f179ca86ad5d5fb88dfd8e8e7c448f2c0ad550d22152f939b8465baeaf9289e9",
+    "zh:f54dda271fa6dfee06537066278669a3f92c872e7dfa5a0184cd9117f7e47b8c",
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -3,27 +3,27 @@ Module to handle secrets for AWS (ECS) services
 
 ## Configuration
 <!-- BEGIN_TF_DOCS -->
-## Requirements
+### Requirements
 
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.9 |
 
-## Providers
+### Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | 5.88.0 |
 
-## Modules
+### Modules
 
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_path"></a> [path](#module\_path) | cloudposse/label/null | 0.25.0 |
 | <a name="module_secret_path"></a> [secret\_path](#module\_secret\_path) | cloudposse/label/null | 0.25.0 |
 
-## Resources
+### Resources
 
 | Name | Type |
 |------|------|
@@ -31,7 +31,7 @@ Module to handle secrets for AWS (ECS) services
 | [aws_secretsmanager_secret_version.secrets](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret_version) | resource |
 | [aws_secretsmanager_secret.existing](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/secretsmanager_secret) | data source |
 
-## Inputs
+### Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
@@ -41,7 +41,7 @@ Module to handle secrets for AWS (ECS) services
 | <a name="input_path_tags"></a> [path\_tags](#input\_path\_tags) | Additional tags for appending to the context and label tags for the path | `map(string)` | `{}` | no |
 | <a name="input_secrets"></a> [secrets](#input\_secrets) | Map of secrets, each key will be the name. When the value is set, a secret is created. Otherwise the arn of existing secret is added to the outputs. | <pre>map(object({<br/>    value          = optional(string)<br/>    value_from_arn = optional(string)<br/>  }))</pre> | n/a | yes |
 
-## Outputs
+### Outputs
 
 | Name | Description |
 |------|-------------|

--- a/README.md
+++ b/README.md
@@ -1,2 +1,51 @@
-# terraform-service-secrets
-Module to handle secrets for (ECS) services
+# terraform-aws-service-secrets
+Module to handle secrets for AWS (ECS) services
+
+## Configuration
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.9 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.88.0 |
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_path"></a> [path](#module\_path) | cloudposse/label/null | 0.25.0 |
+| <a name="module_secret_path"></a> [secret\_path](#module\_secret\_path) | cloudposse/label/null | 0.25.0 |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_secretsmanager_secret.secrets](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret) | resource |
+| [aws_secretsmanager_secret_version.secrets](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret_version) | resource |
+| [aws_secretsmanager_secret.existing](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/secretsmanager_secret) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_context"></a> [context](#input\_context) | Single object for setting entire context at once.<br/>See description of individual variables for details.<br/>Leave string and numeric variables as `null` to use default value.<br/>Individual variable settings (non-null) override settings in context object,<br/>except for attributes, tags, and additional\_tag\_map, which are merged. | `any` | <pre>{<br/>  "additional_tag_map": {},<br/>  "attributes": [],<br/>  "delimiter": null,<br/>  "descriptor_formats": {},<br/>  "enabled": true,<br/>  "environment": null,<br/>  "id_length_limit": null,<br/>  "label_key_case": null,<br/>  "label_order": [],<br/>  "label_value_case": null,<br/>  "labels_as_tags": [<br/>    "unset"<br/>  ],<br/>  "name": null,<br/>  "namespace": null,<br/>  "regex_replace_chars": null,<br/>  "stage": null,<br/>  "tags": {},<br/>  "tenant": null<br/>}</pre> | no |
+| <a name="input_kms_key_id"></a> [kms\_key\_id](#input\_kms\_key\_id) | ARN or Id of the AWS KMS key to be used to encrypt the secret values in the versions stored in this secret. If you need to reference a CMK in a different account, you can use only the key ARN. | `string` | n/a | yes |
+| <a name="input_path_delimiter"></a> [path\_delimiter](#input\_path\_delimiter) | Delimiter to use in the path creation | `string` | `"/"` | no |
+| <a name="input_path_tags"></a> [path\_tags](#input\_path\_tags) | Additional tags for appending to the context and label tags for the path | `map(string)` | `{}` | no |
+| <a name="input_secrets"></a> [secrets](#input\_secrets) | Map of secrets, each key will be the name. When the value is set, a secret is created. Otherwise the arn of existing secret is added to the outputs. | <pre>map(object({<br/>    value          = optional(string)<br/>    value_from_arn = optional(string)<br/>  }))</pre> | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_arns"></a> [arns](#output\_arns) | List of ARNs of the secrets - to use in IAM policies |
+| <a name="output_container_definition"></a> [container\_definition](#output\_container\_definition) | List of secrets maps in the format: { name = <name>, valueFrom = <arn> } - to use in container definitions |
+| <a name="output_secrets"></a> [secrets](#output\_secrets) | Map of secrets, each key is the name, the value is the secret resource |
+<!-- END_TF_DOCS -->

--- a/README.md
+++ b/README.md
@@ -1,6 +1,63 @@
 # terraform-aws-service-secrets
 Module to handle secrets for AWS (ECS) services
 
+## Example
+
+```terraform
+module "service_secrets" {
+  source = "./"
+
+  kms_key_id = "<KMS_KEY_ID>"
+  secrets = {
+    db_pass = {
+      value       = "DatabaseP@ssw0rd!"
+      description = "Password for the Database"
+    }
+    use_already_set_secret = {
+      value_from_arn = "arn:aws:secretsmanager:<REGION>:<ACCOUNT_ID>:secret:<SECRET_NAME>"
+      description    = "Secret that has already been set can also be reused"
+    }
+  }
+}
+
+data "aws_iam_policy_document" "secrets" {
+  statement {
+    sid       = "GetSecrets"
+    effect    = "Allow"
+    actions   = [
+      "secretsmanager:GetSecretValue"
+    ]
+    resources = module.service_secrets.arns
+  }
+  statement {
+    sid       = "kmsDecrypt"
+    effect    = "Allow"
+    actions   = [
+      "kms:Decrypt"
+    ]
+    resources = [
+      module.service_secrets.kms_key_arn
+    ]
+  }
+}
+
+module "container_definition" {
+  source  = "cloudposse/ecs-container-definition/aws"
+  version = "0.61.1"
+
+  container_name = "service"
+  container_image = "docker/service-image"
+
+  environment = [
+    {
+      name  = "ENVIRONMENT",
+      value = "production"
+    }
+  ]
+  secrets     = module.service_secrets.container_definition
+}
+```
+
 ## Configuration
 <!-- BEGIN_TF_DOCS -->
 ### Requirements
@@ -29,6 +86,7 @@ Module to handle secrets for AWS (ECS) services
 |------|------|
 | [aws_secretsmanager_secret.secrets](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret) | resource |
 | [aws_secretsmanager_secret_version.secrets](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret_version) | resource |
+| [aws_kms_key.kms_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/kms_key) | data source |
 | [aws_secretsmanager_secret.existing](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/secretsmanager_secret) | data source |
 
 ### Inputs
@@ -36,10 +94,10 @@ Module to handle secrets for AWS (ECS) services
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_context"></a> [context](#input\_context) | Single object for setting entire context at once.<br/>See description of individual variables for details.<br/>Leave string and numeric variables as `null` to use default value.<br/>Individual variable settings (non-null) override settings in context object,<br/>except for attributes, tags, and additional\_tag\_map, which are merged. | `any` | <pre>{<br/>  "additional_tag_map": {},<br/>  "attributes": [],<br/>  "delimiter": null,<br/>  "descriptor_formats": {},<br/>  "enabled": true,<br/>  "environment": null,<br/>  "id_length_limit": null,<br/>  "label_key_case": null,<br/>  "label_order": [],<br/>  "label_value_case": null,<br/>  "labels_as_tags": [<br/>    "unset"<br/>  ],<br/>  "name": null,<br/>  "namespace": null,<br/>  "regex_replace_chars": null,<br/>  "stage": null,<br/>  "tags": {},<br/>  "tenant": null<br/>}</pre> | no |
-| <a name="input_kms_key_id"></a> [kms\_key\_id](#input\_kms\_key\_id) | ARN or Id of the AWS KMS key to be used to encrypt the secret values in the versions stored in this secret. If you need to reference a CMK in a different account, you can use only the key ARN. | `string` | n/a | yes |
+| <a name="input_kms_key_id"></a> [kms\_key\_id](#input\_kms\_key\_id) | KMS Key identifier to be used to encrypt the secret values in the versions stored in this secret. Can be in any of the formats: Key ID, Key ARN, Alias Name, Alias ARN | `string` | n/a | yes |
 | <a name="input_path_delimiter"></a> [path\_delimiter](#input\_path\_delimiter) | Delimiter to use in the path creation | `string` | `"/"` | no |
 | <a name="input_path_tags"></a> [path\_tags](#input\_path\_tags) | Additional tags for appending to the context and label tags for the path | `map(string)` | `{}` | no |
-| <a name="input_secrets"></a> [secrets](#input\_secrets) | Map of secrets, each key will be the name. When the value is set, a secret is created. Otherwise the arn of existing secret is added to the outputs. | <pre>map(object({<br/>    value          = optional(string)<br/>    value_from_arn = optional(string)<br/>  }))</pre> | n/a | yes |
+| <a name="input_secrets"></a> [secrets](#input\_secrets) | Map of secrets, each key will be the name. When the value is set, a secret is created. Otherwise the arn of existing secret is added to the outputs. | <pre>map(object({<br/>    value          = optional(string)<br/>    description    = optional(string)<br/>    value_from_arn = optional(string)<br/>  }))</pre> | n/a | yes |
 
 ### Outputs
 
@@ -47,5 +105,7 @@ Module to handle secrets for AWS (ECS) services
 |------|-------------|
 | <a name="output_arns"></a> [arns](#output\_arns) | List of ARNs of the secrets - to use in IAM policies |
 | <a name="output_container_definition"></a> [container\_definition](#output\_container\_definition) | List of secrets maps in the format: { name = <name>, valueFrom = <arn> } - to use in container definitions |
+| <a name="output_kms_key_arn"></a> [kms\_key\_arn](#output\_kms\_key\_arn) | ARN of the KMS key used to encrypt the secret values |
+| <a name="output_kms_key_id"></a> [kms\_key\_id](#output\_kms\_key\_id) | ID of the KMS key used to encrypt the secret values |
 | <a name="output_secrets"></a> [secrets](#output\_secrets) | Map of secrets, each key is the name, the value is the secret resource |
 <!-- END_TF_DOCS -->

--- a/create-secrets.tf
+++ b/create-secrets.tf
@@ -3,32 +3,34 @@ locals {
     for key, value in var.secrets : key => value
     if contains(keys(value), "value")
   }
+  secrets_to_create_keys_set = toset(keys(local.secrets_to_create))
+
 }
 
 module "secret_path" {
   source  = "cloudposse/label/null"
   version = "0.25.0"
 
-  for_each = local.secrets_to_create
+  for_each = local.secrets_to_create_keys_set
 
   context    = module.path.context
-  attributes = []
+  attributes = [each.key]
 }
 
 resource "aws_secretsmanager_secret" "secrets" {
-  for_each = local.secrets_to_create
+  for_each = local.secrets_to_create_keys_set
 
   name        = module.secret_path[each.key].id
-  description = each.value.description
-  kms_key_id  = var.kms_key_id
+  description = local.secrets_to_create[each.key].description
+  kms_key_id  = data.aws_kms_key.kms_key.arn
 
   tags = module.secret_path[each.key].tags
 }
 
 resource "aws_secretsmanager_secret_version" "secrets" {
-  for_each = local.secrets_to_create
+  for_each = local.secrets_to_create_keys_set
 
   secret_id = aws_secretsmanager_secret.secrets[each.key].id
 
-  secret_string = each.value.value
+  secret_string = local.secrets_to_create[each.key].value
 }

--- a/create-secrets.tf
+++ b/create-secrets.tf
@@ -17,7 +17,6 @@ module "secret_path" {
   attributes = [each.key]
 }
 
-# checkov:skip=CKV2_AWS_57: Automatic rotation is not required for the purpose of this module (at the moment)
 resource "aws_secretsmanager_secret" "secrets" {
   for_each = local.secrets_to_create_keys_set
 

--- a/create-secrets.tf
+++ b/create-secrets.tf
@@ -17,6 +17,7 @@ module "secret_path" {
   attributes = [each.key]
 }
 
+# checkov:skip=CKV2_AWS_57: Automatic rotation is not required for the purpose of this module (at the moment)
 resource "aws_secretsmanager_secret" "secrets" {
   for_each = local.secrets_to_create_keys_set
 

--- a/create-secrets.tf
+++ b/create-secrets.tf
@@ -1,0 +1,34 @@
+locals {
+  secrets_to_create = {
+    for key, value in var.secrets : key => value
+    if contains(keys(value), "value")
+  }
+}
+
+module "secret_path" {
+  source  = "cloudposse/label/null"
+  version = "0.25.0"
+
+  for_each = local.secrets_to_create
+
+  context    = module.path.context
+  attributes = []
+}
+
+resource "aws_secretsmanager_secret" "secrets" {
+  for_each = local.secrets_to_create
+
+  name        = module.secret_path[each.key].id
+  description = each.value.description
+  kms_key_id  = var.kms_key_id
+
+  tags = module.secret_path[each.key].tags
+}
+
+resource "aws_secretsmanager_secret_version" "secrets" {
+  for_each = local.secrets_to_create
+
+  secret_id = aws_secretsmanager_secret.secrets[each.key].id
+
+  secret_string = each.value.value
+}

--- a/existing-secrets.tf
+++ b/existing-secrets.tf
@@ -1,0 +1,12 @@
+locals {
+  existing_secrets = {
+    for key, value in var.secrets : key => value.value_from_arn
+    if contains(keys(value), "value_from_arn")
+  }
+}
+
+data "aws_secretsmanager_secret" "existing" {
+  for_each = local.existing_secrets
+
+  arn = each.value
+}

--- a/existing-secrets.tf
+++ b/existing-secrets.tf
@@ -3,10 +3,12 @@ locals {
     for key, value in var.secrets : key => value.value_from_arn
     if contains(keys(value), "value_from_arn")
   }
+
+  existing_secrets_keys_set = toset(keys(local.existing_secrets))
 }
 
 data "aws_secretsmanager_secret" "existing" {
-  for_each = local.existing_secrets
+  for_each = local.existing_secrets_keys_set
 
-  arn = each.value
+  arn = local.existing_secrets[each.key]
 }

--- a/kms-key.tf
+++ b/kms-key.tf
@@ -1,0 +1,3 @@
+data "aws_kms_key" "kms_key" {
+  key_id = var.kms_key_id
+}

--- a/main.tf
+++ b/main.tf
@@ -1,0 +1,8 @@
+module "path" {
+  source  = "cloudposse/label/null"
+  version = "0.25.0"
+
+  context   = var.context
+  delimiter = var.path_delimiter
+  tags      = var.path_tags
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -24,3 +24,13 @@ output "container_definition" {
   value       = local.secrets_container_definition
   description = "List of secrets maps in the format: { name = <name>, valueFrom = <arn> } - to use in container definitions"
 }
+
+output "kms_key_arn" {
+  value       = data.aws_kms_key.kms_key.arn
+  description = "ARN of the KMS key used to encrypt the secret values"
+}
+
+output "kms_key_id" {
+  value       = data.aws_kms_key.kms_key.key_id
+  description = "ID of the KMS key used to encrypt the secret values"
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,0 +1,26 @@
+locals {
+  secrets = merge(data.aws_secretsmanager_secret.existing, aws_secretsmanager_secret.secrets)
+
+  secret_arns = [for _key, secret in local.secrets : secret.arn]
+  secrets_container_definition = [for key, secret in local.secrets :
+    {
+      name      = key
+      valueFrom = secret.arn
+    }
+  ]
+}
+
+output "secrets" {
+  value       = local.secrets
+  description = "Map of secrets, each key is the name, the value is the secret resource"
+}
+
+output "arns" {
+  value       = local.secret_arns
+  description = "List of ARNs of the secrets - to use in IAM policies"
+}
+
+output "container_definition" {
+  value       = local.secrets_container_definition
+  description = "List of secrets maps in the format: { name = <name>, valueFrom = <arn> } - to use in container definitions"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,85 @@
+variable "context" {
+  type = any
+  default = {
+    enabled             = true
+    namespace           = null
+    tenant              = null
+    environment         = null
+    stage               = null
+    name                = null
+    delimiter           = null
+    attributes          = []
+    tags                = {}
+    additional_tag_map  = {}
+    regex_replace_chars = null
+    label_order         = []
+    id_length_limit     = null
+    label_key_case      = null
+    label_value_case    = null
+    descriptor_formats  = {}
+    # Note: we have to use [] instead of null for unset lists due to
+    # https://github.com/hashicorp/terraform/issues/28137
+    # which was not fixed until Terraform 1.0.0,
+    # but we want the default to be all the labels in `label_order`
+    # and we want users to be able to prevent all tag generation
+    # by setting `labels_as_tags` to `[]`, so we need
+    # a different sentinel to indicate "default"
+    labels_as_tags = ["unset"]
+  }
+  description = <<-EOT
+    Single object for setting entire context at once.
+    See description of individual variables for details.
+    Leave string and numeric variables as `null` to use default value.
+    Individual variable settings (non-null) override settings in context object,
+    except for attributes, tags, and additional_tag_map, which are merged.
+  EOT
+
+  validation {
+    condition     = lookup(var.context, "label_key_case", null) == null ? true : contains(["lower", "title", "upper"], var.context["label_key_case"])
+    error_message = "Allowed values: `lower`, `title`, `upper`."
+  }
+
+  validation {
+    condition     = lookup(var.context, "label_value_case", null) == null ? true : contains(["lower", "title", "upper", "none"], var.context["label_value_case"])
+    error_message = "Allowed values: `lower`, `title`, `upper`, `none`."
+  }
+}
+
+variable "path_delimiter" {
+  type        = string
+  description = "Delimiter to use in the path creation"
+  default     = "/"
+}
+
+variable "kms_key_id" {
+  type        = string
+  description = "ARN or Id of the AWS KMS key to be used to encrypt the secret values in the versions stored in this secret. If you need to reference a CMK in a different account, you can use only the key ARN."
+}
+
+variable "secrets" {
+  type = map(object({
+    value          = optional(string)
+    value_from_arn = optional(string)
+  }))
+  sensitive   = true
+  description = "Map of secrets, each key will be the name. When the value is set, a secret is created. Otherwise the arn of existing secret is added to the outputs."
+
+  validation {
+    condition = alltrue([
+      for key, value in var.secrets : contains(keys(value), "value") || contains(keys(value), "value_from_arn")
+    ])
+    error_message = "value or value_from_arn must be set for each secret"
+  }
+  validation {
+    condition = !anytrue([
+      for key, value in var.secrets : (contains(keys(value), "value") && contains(keys(value), "value_from_arn"))
+    ])
+    error_message = "value and value_from_arn cannot be set at the same time"
+  }
+}
+
+variable "path_tags" {
+  type        = map(string)
+  default     = {}
+  description = "Additional tags for appending to the context and label tags for the path"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -53,12 +53,13 @@ variable "path_delimiter" {
 
 variable "kms_key_id" {
   type        = string
-  description = "ARN or Id of the AWS KMS key to be used to encrypt the secret values in the versions stored in this secret. If you need to reference a CMK in a different account, you can use only the key ARN."
+  description = "KMS Key identifier to be used to encrypt the secret values in the versions stored in this secret. Can be in any of the formats: Key ID, Key ARN, Alias Name, Alias ARN"
 }
 
 variable "secrets" {
   type = map(object({
     value          = optional(string)
+    description    = optional(string)
     value_from_arn = optional(string)
   }))
   sensitive   = true

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.3"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.9"
+    }
+  }
+}


### PR DESCRIPTION
Module to create and use secrets in AWS ECS.

### Resources

| Name | Type |
|------|------|
| [aws_secretsmanager_secret.secrets](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret) | resource |
| [aws_secretsmanager_secret_version.secrets](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret_version) | resource |
| [aws_secretsmanager_secret.existing](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/secretsmanager_secret) | data source |

### Inputs

| Name | Description | Type | Default | Required |
|------|-------------|------|---------|:--------:|
| <a name="input_context"></a> [context](#input\_context) | Single object for setting entire context at once.<br/>See description of individual variables for details.<br/>Leave string and numeric variables as `null` to use default value.<br/>Individual variable settings (non-null) override settings in context object,<br/>except for attributes, tags, and additional\_tag\_map, which are merged. | `any` | <pre>{<br/>  "additional_tag_map": {},<br/>  "attributes": [],<br/>  "delimiter": null,<br/>  "descriptor_formats": {},<br/>  "enabled": true,<br/>  "environment": null,<br/>  "id_length_limit": null,<br/>  "label_key_case": null,<br/>  "label_order": [],<br/>  "label_value_case": null,<br/>  "labels_as_tags": [<br/>    "unset"<br/>  ],<br/>  "name": null,<br/>  "namespace": null,<br/>  "regex_replace_chars": null,<br/>  "stage": null,<br/>  "tags": {},<br/>  "tenant": null<br/>}</pre> | no |
| <a name="input_kms_key_id"></a> [kms\_key\_id](#input\_kms\_key\_id) | ARN or Id of the AWS KMS key to be used to encrypt the secret values in the versions stored in this secret. If you need to reference a CMK in a different account, you can use only the key ARN. | `string` | n/a | yes |
| <a name="input_path_delimiter"></a> [path\_delimiter](#input\_path\_delimiter) | Delimiter to use in the path creation | `string` | `"/"` | no |
| <a name="input_path_tags"></a> [path\_tags](#input\_path\_tags) | Additional tags for appending to the context and label tags for the path | `map(string)` | `{}` | no |
| <a name="input_secrets"></a> [secrets](#input\_secrets) | Map of secrets, each key will be the name. When the value is set, a secret is created. Otherwise the arn of existing secret is added to the outputs. | <pre>map(object({<br/>    value          = optional(string)<br/>    value_from_arn = optional(string)<br/>  }))</pre> | n/a | yes |

### Outputs

| Name | Description |
|------|-------------|
| <a name="output_arns"></a> [arns](#output\_arns) | List of ARNs of the secrets - to use in IAM policies |
| <a name="output_container_definition"></a> [container\_definition](#output\_container\_definition) | List of secrets maps in the format: { name = <name>, valueFrom = <arn> } - to use in container definitions |
| <a name="output_secrets"></a> [secrets](#output\_secrets) | Map of secrets, each key is the name, the value is the secret resource |