### PR TITLE
A secret is always created when value_from_arn is not set

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ module "container_definition" {
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.88.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.90.0 |
 
 ### Modules
 

--- a/create-secrets.tf
+++ b/create-secrets.tf
@@ -1,7 +1,7 @@
 locals {
   secrets_to_create = {
     for key, value in var.secrets : key => value
-    if value.value != null
+    if value.value_from_arn == null
   }
   secrets_to_create_keys_set = nonsensitive(toset(keys(local.secrets_to_create)))
 }


### PR DESCRIPTION
When a secret contains a value which is computed (for example from `random_password`), the module can't determine whether the value will be set or will be `null`. Therefore it cannot compute the list of secrets to be created even when it is a map.
But checking whether value_from_arn is `null` can always be done.