### PR TITLE
Fix IAM policy

### DIFF
--- a/.terraform-docs.yml
+++ b/.terraform-docs.yml
@@ -1,6 +1,6 @@
 formatter: markdown
 
-version: 0.19.0
+version: 0.20.0
 
 output:
   file: "README.md"

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ module "container_definition" {
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.12.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.13.0 |
 
 ### Modules
 

--- a/policy-document.tf
+++ b/policy-document.tf
@@ -26,7 +26,7 @@ data "aws_iam_policy_document" "secrets_access" {
       "kms:GenerateDataKey"
     ]
 
-    resources = data.aws_kms_key.secrets[*].arn
+    resources = [for k in data.aws_kms_key.secrets : k.arn]
   }
 }
 


### PR DESCRIPTION
Fixes an issue when applying the IAM policy:

```
Error: Unsupported attribute
  on .terraform\modules\secrets\policy-document.tf line 29, in data "aws_iam_policy_document" "secrets_access":
  29:     resources = data.aws_kms_key.secrets[*].arn
This object does not have an attribute named "arn".
```

Because this is a set, it doesn't seem to directly support the `[*]` notation (replacing the `*` with an actual hardcoded uuid of a key did seem to work, so this might be a TF bug). Iterating over the set and extracting the arn value with a `for` loop seems to fix the issue.
