### PR TITLE
Add comment to skip Checkov rule for secret rotation

### DIFF
--- a/create-secrets.tf
+++ b/create-secrets.tf
@@ -25,6 +25,7 @@ locals {
 }
 
 resource "aws_secretsmanager_secret" "secrets" {
+  #checkov:skip=CKV2_AWS_57: Currently the module doesn't support rotation of secrets and this is not required at the moment for usage within Luscii.
   for_each = toset(local.secrets_to_actually_create)
 
   name        = module.secret_path[each.key].id


### PR DESCRIPTION
Skip Checkov rule CKV2_AWS_57 regarding secret rotation as this is too complex and not required for Luscii at the moment