### PR TITLE
Sanitize SID values in IAM policy documents for SSM parameter access

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ module "container_definition" {
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.13.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.26.0 |
 
 ### Modules
 

--- a/policy-document.tf
+++ b/policy-document.tf
@@ -34,7 +34,7 @@ data "aws_iam_policy_document" "params_access" {
   count = local.has_params ? 1 : 0
 
   statement {
-    sid    = join("", [module.base_id.id, "ParamsAccess"])
+    sid    = replace(join("", [module.base_id.id, "ParamsAccess"]), "/[^a-zA-Z0-9]/", "")
     effect = "Allow"
 
     actions = [
@@ -50,7 +50,7 @@ data "aws_iam_policy_document" "params_access" {
     for_each = length([for k, v in var.parameters : v.sensitive if v.sensitive == true]) > 0 ? { kms = "kms" } : {}
 
     content {
-      sid    = join("", [module.base_id.id, "ParamsKmsDecrypt"])
+      sid    = replace(join("", [module.base_id.id, "ParamsKmsDecrypt"]), "/[^a-zA-Z0-9]/", "")
       effect = "Allow"
 
       actions = [


### PR DESCRIPTION
- Updated the SID for the ParamsAccess and ParamsKmsDecrypt statements in the params_access policy document to remove non-alphanumeric characters using the `replace` function.
- Ensures generated SIDs are compliant with AWS requirements and avoid invalid characters.