### PR TITLE
Sanitize SID values in IAM policy documents for SSM parameter access

### DIFF
--- a/policy-document.tf
+++ b/policy-document.tf
@@ -7,7 +7,7 @@ data "aws_iam_policy_document" "secrets_access" {
   count = local.has_secrets ? 1 : 0
 
   statement {
-    sid    = join("", [module.base_id.id, "SecretsAccess"])
+    sid    = replace(join("", [module.base_id.id, "SecretsAccess"]), "/[^a-zA-Z0-9]/", "")
     effect = "Allow"
 
     actions = [
@@ -18,7 +18,7 @@ data "aws_iam_policy_document" "secrets_access" {
   }
 
   statement {
-    sid    = join("", [module.base_id.id, "SecretsKmsDecrypt"])
+    sid    = replace(join("", [module.base_id.id, "SecretsKmsDecrypt"]), "/[^a-zA-Z0-9]/", "")
     effect = "Allow"
 
     actions = [


### PR DESCRIPTION
- Updated the SID for the SecretAccess and SecretKmsDecrypt statements in the params_access policy document to remove non-alphanumeric characters using the replace function.