### PR TITLE
chore: add usage skill for service-secrets module

### DIFF
--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -1,0 +1,216 @@
+---
+name: using-service-secrets
+description: 'Guides usage of the terraform-aws-service-secrets module for managing AWS Secrets Manager secrets and SSM Parameters consumed by ECS services. Use when asked to "add a secret", "add a parameter", "configure secrets", "use service-secrets module", "ECS secrets", "SSM parameters", or working with this Terraform module.'
+---
+
+# Using the service-secrets Module
+
+Manages AWS Secrets Manager secrets and SSM Parameters for ECS services, with automatic IAM policy generation and ECS container definition output.
+
+## Key Concepts
+
+- **Secrets**: Stored in AWS Secrets Manager, always encrypted with KMS
+- **Parameters**: Stored in AWS SSM Parameter Store, optionally encrypted (SecureString) or plain (String)
+- **Dual-mode**: Each secret/parameter can be **created** (provide `value`) or **referenced** (provide `value_from_arn`)
+- **Outputs**: The module produces ready-to-use IAM policies and ECS container definition fragments
+
+## Usage Workflow
+
+Copy and track:
+```
+Progress:
+- [ ] Step 1: Configure module source and context
+- [ ] Step 2: Set up KMS key (required for secrets, required for sensitive parameters)
+- [ ] Step 3: Define secrets and/or parameters
+- [ ] Step 4: Wire outputs to ECS task definition and execution role
+- [ ] Step 5: Validate with terraform plan
+```
+
+### Step 1: Configure Module Source and Context
+
+```hcl
+module "service_secrets" {
+  source = "github.com/Luscii/terraform-aws-service-secrets?ref=<version>"
+
+  context = module.this.context  # CloudPosse label context
+}
+```
+
+The `context` variable drives naming and tagging via CloudPosse label modules. The generated path becomes the prefix for all secret and parameter names (e.g., `/<namespace>/<environment>/<name>/<secret-key>`).
+
+### Step 2: Set Up KMS Key
+
+```hcl
+module "service_secrets" {
+  # ...
+  kms_key_id = aws_kms_key.secrets.id  # or alias, ARN
+}
+```
+
+**Required when**: creating secrets or sensitive (SecureString) parameters.
+**Not required when**: only creating non-sensitive (String) parameters or only referencing existing resources.
+
+### Step 3: Define Secrets and Parameters
+
+**Creating new secrets:**
+```hcl
+secrets = {
+  db_password = {
+    value       = var.db_password
+    description = "Database password"
+  }
+  api_key = {
+    value       = var.api_key
+    description = "Third-party API key"
+  }
+}
+```
+
+**Referencing existing secrets:**
+```hcl
+secrets = {
+  shared_secret = {
+    value_from_arn = "arn:aws:secretsmanager:eu-west-1:123456789012:secret:shared-abc123"
+    description    = "Secret managed elsewhere"
+  }
+}
+```
+
+**Creating parameters (non-sensitive):**
+```hcl
+parameters = {
+  log_level = {
+    value       = "info"
+    description = "Application log level"
+  }
+}
+```
+
+**Creating sensitive parameters (SecureString with KMS):**
+```hcl
+parameters = {
+  connection_string = {
+    value       = var.connection_string
+    sensitive   = true
+    description = "Database connection string"
+  }
+}
+```
+
+**Referencing existing parameters:**
+```hcl
+parameters = {
+  shared_config = {
+    value_from_arn = "arn:aws:ssm:eu-west-1:123456789012:parameter/shared/config"
+    description    = "Shared configuration parameter"
+  }
+}
+```
+
+For full variable details, see [references/variables.md](references/variables.md).
+
+### Step 4: Wire Outputs to ECS
+
+**Attach IAM policy to the ECS task execution role:**
+```hcl
+resource "aws_iam_role_policy" "secrets" {
+  name   = "service-secrets"
+  role   = aws_iam_role.execution.id
+  policy = module.service_secrets.iam_policy_document
+}
+```
+
+**Pass secrets to ECS container definition:**
+```hcl
+module "container_definition" {
+  source  = "cloudposse/ecs-container-definition/aws"
+  version = "0.61.1"
+
+  container_name  = "app"
+  container_image = "123456789012.dkr.ecr.eu-west-1.amazonaws.com/app:latest"
+
+  secrets = module.service_secrets.container_definition
+}
+```
+
+The `container_definition` output is a list of `{ name, valueFrom }` maps where `name` is the map key (uppercased by ECS as environment variable name) and `valueFrom` is the ARN.
+
+For all available outputs, see [references/outputs.md](references/outputs.md).
+
+### Step 5: Validate
+
+```bash
+terraform plan
+```
+
+Check that:
+- Secrets and parameters are created with correct names/paths
+- IAM policy grants `secretsmanager:GetSecretValue` and/or `ssm:GetParameter*`
+- KMS decrypt permissions are included when using encrypted values
+
+## Important Rules
+
+1. **`value` and `value_from_arn` are mutually exclusive** - set one or the other per entry, never both
+2. **`kms_key_id` is required** when creating secrets or sensitive parameters - the module will fail with a precondition error otherwise
+3. **ARN format validation** is strict:
+   - Secrets: `arn:aws:secretsmanager:<region>:<account>:secret:<name>-<6chars>`
+   - Parameters: `arn:aws:ssm:<region>:<account>:parameter/<name>`
+4. **Parameter tier** defaults to `Advanced` - use `Standard` only if you don't need values > 4KB
+5. **Sensitive parameters** (`sensitive = true`) use SecureString type and require KMS
+
+## Common Patterns
+
+### Secrets-only (no parameters)
+```hcl
+module "service_secrets" {
+  source     = "github.com/Luscii/terraform-aws-service-secrets?ref=<version>"
+  context    = module.this.context
+  kms_key_id = aws_kms_key.secrets.id
+
+  secrets = {
+    db_pass = { value = var.db_password }
+  }
+}
+```
+
+### Parameters-only (non-sensitive)
+```hcl
+module "service_secrets" {
+  source  = "github.com/Luscii/terraform-aws-service-secrets?ref=<version>"
+  context = module.this.context
+
+  parameters = {
+    log_level = { value = "info" }
+    region    = { value = "eu-west-1" }
+  }
+}
+# No kms_key_id needed for non-sensitive parameters
+```
+
+### Mixed: new + existing
+```hcl
+module "service_secrets" {
+  source     = "github.com/Luscii/terraform-aws-service-secrets?ref=<version>"
+  context    = module.this.context
+  kms_key_id = aws_kms_key.secrets.id
+
+  secrets = {
+    new_secret      = { value = var.secret_value }
+    existing_secret = { value_from_arn = "arn:aws:secretsmanager:..." }
+  }
+
+  parameters = {
+    new_param      = { value = "config-value" }
+    existing_param = { value_from_arn = "arn:aws:ssm:..." }
+  }
+}
+```
+
+## Troubleshooting
+
+| Problem | Cause | Solution |
+|---------|-------|----------|
+| Precondition failed: KMS key required | Creating SecureString param without `kms_key_id` | Set `kms_key_id` or change `sensitive = false` |
+| ARN validation error | `value_from_arn` doesn't match expected format | Check ARN format (secrets need 6-char suffix) |
+| Both value and value_from_arn set | Mutually exclusive fields | Use only one per entry |
+| Empty IAM policy output | No secrets or parameters defined | Add at least one secret or parameter |

--- a/skill/references/outputs.md
+++ b/skill/references/outputs.md
@@ -1,0 +1,63 @@
+# Outputs Reference
+
+## ECS Integration Outputs
+
+These are the primary outputs for wiring into ECS task definitions.
+
+### container_definition
+Combined list of secrets and parameters formatted for ECS container definitions.
+- Type: `list(object({ name = string, valueFrom = string }))`
+- Usage: Pass directly to the `secrets` argument of an ECS container definition module
+
+### secrets_container_definition
+List of only secrets in `{ name, valueFrom }` format.
+
+### params_container_definition
+List of only parameters in `{ name, valueFrom }` format.
+
+## IAM Policy Outputs
+
+Ready-to-use JSON IAM policy documents for ECS task execution roles.
+
+### iam_policy_document
+Combined IAM policy document granting access to all defined secrets and parameters. Includes:
+- `secretsmanager:GetSecretValue` for secrets
+- `ssm:GetParameter`, `ssm:GetParameters`, `ssm:GetParametersByPath` for parameters
+- `kms:Decrypt`, `kms:GenerateDataKey` for encrypted resources
+
+### secrets_iam_policy_document
+IAM policy document for secrets access only.
+
+### parameters_iam_policy_document
+IAM policy document for parameters access only.
+
+## Resource Metadata Outputs
+
+### secrets
+Map of created/referenced secret metadata (excludes actual values).
+- Type: `map(object({ arn, id, name, description }))`
+
+### secret_version_ids
+Map of secret version IDs.
+- Type: `map(string)`
+
+### secret_arns
+Flat list of all secret ARNs.
+
+### parameters
+Map of created/referenced parameter metadata (excludes actual values).
+- Type: `map(object({ arn, id, name, description, type, data_type, version }))`
+
+### parameters_arns
+Flat list of all parameter ARNs.
+
+### arns
+Combined flat list of all secret and parameter ARNs.
+
+## KMS Key Outputs
+
+### kms_key_arn
+ARN of the KMS key, or `null` if no `kms_key_id` was provided.
+
+### kms_key_id
+ID of the KMS key, or `null` if no `kms_key_id` was provided.

--- a/skill/references/variables.md
+++ b/skill/references/variables.md
@@ -1,0 +1,103 @@
+# Variables Reference
+
+## kms_key_id
+
+| Property | Value |
+|----------|-------|
+| Type | `string` |
+| Default | `null` |
+| Required | No (but required when creating secrets or sensitive parameters) |
+
+KMS Key identifier for encrypting secret values. Accepts: Key ID, Key ARN, Alias Name, or Alias ARN.
+
+## secrets
+
+| Property | Value |
+|----------|-------|
+| Type | `map(object({ value, description, value_from_arn }))` |
+| Default | `{}` |
+| Sensitive | Yes |
+
+Map of secrets where each key becomes the secret name suffix.
+
+### Secret object fields
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `value` | `string` | One of value/value_from_arn | The secret value. Creates a new Secrets Manager secret. |
+| `description` | `string` | No | Description for the secret |
+| `value_from_arn` | `string` | One of value/value_from_arn | ARN of an existing secret to reference |
+
+### Validations
+- `value` and `value_from_arn` are mutually exclusive
+- `value_from_arn` must match: `arn:aws:secretsmanager:<region>:<account-id>:secret:<name>-<6chars>`
+
+## parameters
+
+| Property | Value |
+|----------|-------|
+| Type | `map(object({ data_type, description, sensitive, tier, value, value_from_arn }))` |
+| Default | `{}` |
+
+Map of SSM parameters where each key becomes the parameter name suffix.
+
+### Parameter object fields
+
+| Field | Type | Default | Required | Description |
+|-------|------|---------|----------|-------------|
+| `value` | `string` | - | One of value/value_from_arn | The parameter value. Creates a new SSM parameter. |
+| `description` | `string` | - | No | Description for the parameter |
+| `sensitive` | `bool` | `false` | No | When `true`, uses SecureString type with KMS encryption |
+| `tier` | `string` | `"Advanced"` | No | One of: `Standard`, `Advanced`, `Intelligent-Tiering` |
+| `data_type` | `string` | `"text"` | No | One of: `text`, `aws:ec2:image`, `aws:ssm:integration` |
+| `value_from_arn` | `string` | - | One of value/value_from_arn | ARN of an existing parameter to reference |
+
+### Validations
+- `value` and `value_from_arn` are mutually exclusive
+- `value_from_arn` must match: `arn:aws:ssm:<region>:<account-id>:parameter/<name>`
+- `data_type` must be one of: `text`, `aws:ec2:image`, `aws:ssm:integration`
+- `tier` must be one of: `Standard`, `Advanced`, `Intelligent-Tiering`
+
+### Parameter type logic
+- `data_type = "aws:ssm:integration"` -> SecureString, no KMS key needed, uses special webhook prefix
+- `sensitive = true` -> SecureString with KMS encryption (requires `kms_key_id`)
+- Otherwise -> String (no encryption)
+
+## context
+
+| Property | Value |
+|----------|-------|
+| Type | `any` |
+| Required | No |
+
+CloudPosse label context object for naming and tagging. Key fields:
+
+| Field | Purpose |
+|-------|---------|
+| `namespace` | Organization or project namespace |
+| `environment` | Environment name (e.g., `prod`, `staging`) |
+| `stage` | Stage within environment |
+| `name` | Service/component name |
+| `delimiter` | Separator for label components |
+| `tags` | Tags to apply to resources |
+| `attributes` | Additional attributes appended to the label |
+
+The context generates the path prefix for all secrets and parameters. For example, with `namespace=luscii`, `environment=prod`, `name=api`, the path becomes `/luscii/prod/api/`.
+
+## path_delimiter
+
+| Property | Value |
+|----------|-------|
+| Type | `string` |
+| Default | `"/"` |
+
+Delimiter used in path construction for secret and parameter names.
+
+## path_tags
+
+| Property | Value |
+|----------|-------|
+| Type | `map(string)` |
+| Default | `{}` |
+
+Additional tags appended to the context tags for path label generation.


### PR DESCRIPTION
## Summary
- Adds a `skill/` directory with a Claude Code skill for guided integration of the `terraform-aws-service-secrets` module
- Includes `SKILL.md` (usage workflow, common patterns, troubleshooting) and reference docs for variables and outputs
- Module source URL uses the correct `github.com/Luscii/terraform-aws-service-secrets?ref=<version>` convention

## Test plan
- [ ] Verify skill content matches actual `variables.tf` and `outputs.tf`
- [ ] Confirm module source URL follows Luscii naming conventions
- [ ] Validate skill structure matches `aws-ecs-service/skill/` pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)