### PR TITLE
chore: rename skill to luscii-service-secrets

### DIFF
--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: using-service-secrets
+name: luscii-service-secrets
 description: 'Guides usage of the terraform-aws-service-secrets module for managing AWS Secrets Manager secrets and SSM Parameters consumed by ECS services. Use when asked to "add a secret", "add a parameter", "configure secrets", "use service-secrets module", "ECS secrets", "SSM parameters", or working with this Terraform module.'
 ---
 


### PR DESCRIPTION
## Summary
- Renames skill from `using-service-secrets` to `luscii-service-secrets` for consistent marketplace naming pattern

## Test plan
- [x] Skill frontmatter name matches directory name
- [x] Consistent with `luscii-<module>` naming convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)